### PR TITLE
Update indexing type for Eigen 3.4 compatibility

### DIFF
--- a/inst/include/tools.h
+++ b/inst/include/tools.h
@@ -36,7 +36,7 @@ void updselel (
         double& prior_blockl,
         const Eigen::MatrixXd priorm,
         const int& i,
-        const arma::vec& index_col,
+        const arma::Col<int>& index_col,
         const arma::rowvec& newval,
         const int& nupdate
 );

--- a/src/toolsbayes.cpp
+++ b/src/toolsbayes.cpp
@@ -131,7 +131,7 @@ void updselel (
     double& prior_blockl,
     const Eigen::MatrixXd priorm,
     const int& i,
-    const arma::vec& index_col,
+    const arma::Col<int>& index_col,
     const arma::rowvec& newval,
     const int& nupdate
 ){

--- a/src/updatenet.cpp
+++ b/src/updatenet.cpp
@@ -300,7 +300,7 @@ void updGnormblock (List& Gnorm,
       Eigen::MatrixXd Am = eyeM-alpha*Gmnorm;
       removeRow(Am,i);
       
-      arma::vec IndexMJ = IndexMIJ[ci];
+      arma::Col<int> IndexMJ = IndexMIJ[ci];
       int NJ = IndexMJ.n_elem;
       
       for(int j(0); j < N(m); ++j) {
@@ -316,7 +316,7 @@ void updGnormblock (List& Gnorm,
       
       
       for(int cj(0); cj<NJeff; ++cj){
-        arma::vec index_col = IndexMJ.subvec(Blocks(cj) + 1, Blocks(cj+1));
+        arma::Col<int> index_col = IndexMJ.subvec(Blocks(cj) + 1, Blocks(cj+1));
         int nupdate         = Blocks(cj+1) - Blocks(cj);
         int poss            = pow(2, nupdate);          // number of possibility
         arma::mat cposs     = possentries(nupdate, poss); // the possibility 
@@ -404,7 +404,7 @@ void updGnormblocknoc (List& Gnorm,
       Eigen::MatrixXd Am = eyeM-alpha*Gmnorm;
       removeRow(Am,i);
       
-      arma::vec IndexMJ = IndexMIJ[ci];
+      arma::Col<int> IndexMJ = IndexMIJ[ci];
       int NJ = IndexMJ.n_elem;
       
       for(int j(0); j < N(m); ++j) {
@@ -420,7 +420,7 @@ void updGnormblocknoc (List& Gnorm,
       
       
       for(int cj(0); cj<NJeff; ++cj){
-        arma::vec index_col = IndexMJ.subvec(Blocks(cj) + 1, Blocks(cj+1));
+        arma::Col<int> index_col = IndexMJ.subvec(Blocks(cj) + 1, Blocks(cj+1));
         int nupdate         = Blocks(cj+1) - Blocks(cj);
         int poss            = pow(2, nupdate);          // number of possibility
         arma::mat cposs     = possentries(nupdate, poss); // the possibility 


### PR DESCRIPTION
This PR updates your package's C++ to use an integer vector (`arma::Col<int>`) instead of a doubles vector (`arma::vec` for storing indexing values, otherwise your package will break with the next RcppEigen release (Eigen 3.4 doesn't allow using `double`s for indexing).

Let me know if you have any questions, thanks!
